### PR TITLE
House Van Saar correction to "Flail" in the melee weapons

### DIFF
--- a/src/data/factions/house_van_saar.toml
+++ b/src/data/factions/house_van_saar.toml
@@ -79,7 +79,7 @@ name = "Fighting knife"
 cost = 10
 
 [weapons.close-combat.flail]
-name = ""
+name = "Flail"
 cost = 20
 
 [weapons.close-combat.two-handed_weapon]


### PR DESCRIPTION
added name = "Flail" as it was unset.